### PR TITLE
Update Genie_Deltalake_AutoUpkeep.ipynb

### DIFF
--- a/utilities/DeltalakeAutoMaintain/Genie_Deltalake_AutoUpkeep.ipynb
+++ b/utilities/DeltalakeAutoMaintain/Genie_Deltalake_AutoUpkeep.ipynb
@@ -742,7 +742,7 @@
       "source": [
         "def get_dir_content(ls_path):\r\n",
         "  baseFilesInfo = mssparkutils.fs.ls(ls_path)\r\n",
-        "  subdir_filesInfo = [get_dir_content(p.path) for p in baseFilesInfo if p.isDir and p.path != ls_path]\r\n",
+        "  subdir_filesInfo = [get_dir_content(p.path) for p in baseFilesInfo if p.isDir() and p.path != ls_path]\r\n",
         "  flat_subdir_FilesInfo = [p for subFileInfo in subdir_filesInfo for p in subFileInfo]\r\n",
         "  return list(map(lambda p: p, baseFilesInfo)) + flat_subdir_FilesInfo"
       ]


### PR DESCRIPTION
Hi, I believe the Genie_Deltalake_AutoUpkeep.ipynb returns too many files; thereby inflating filesizes.

I've tracked it down to p.isDir missing a parenthesis causing all files to be treated as subdir and relisted.

also created issue "get_dir_content() is returning too many files"